### PR TITLE
Invalidity trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "semval"
 description = "Semantic validation"
 keywords = ["semantic", "validation"]
-version = "0.0.6-pre"
+version = "0.0.6"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 authors = ["Uwe Klotz <uwe.klotz@gmail.com>"]

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -20,16 +20,13 @@ impl Validate for Email {
     type Invalidity = EmailInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::new();
-        context.invalidate_if(
-            self.0.len() < Self::min_len(),
-            EmailInvalidity::MinLength,
-        );
-        context.invalidate_if(
-            self.0.chars().filter(|c| *c == '@').count() != 1,
-            EmailInvalidity::Format,
-        );
-        context.into()
+        ValidationContext::new()
+            .invalidate_if(self.0.len() < Self::min_len(), EmailInvalidity::MinLength)
+            .invalidate_if(
+                self.0.chars().filter(|c| *c == '@').count() != 1,
+                EmailInvalidity::Format,
+            )
+            .into()
     }
 }
 
@@ -53,10 +50,7 @@ impl Validate for Phone {
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         let mut context = ValidationContext::new();
         let len = self.0.chars().filter(|c| !c.is_whitespace()).count();
-        context.invalidate_if(
-            len < Self::min_len(),
-            PhoneInvalidity::MinLength,
-        );
+        context = context.invalidate_if(len < Self::min_len(), PhoneInvalidity::MinLength);
         context.into()
     }
 }
@@ -80,13 +74,13 @@ impl Validate for ContactData {
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         let mut context = ValidationContext::new();
         if let Some(ref email) = self.email {
-            context.validate_and_map(email, ContactDataInvalidity::Email)
+            context = context.validate_and_map(email, ContactDataInvalidity::Email)
         }
         if let Some(ref phone) = self.phone {
-            context.validate_and_map(phone, ContactDataInvalidity::Phone)
+            context = context.validate_and_map(phone, ContactDataInvalidity::Phone)
         }
         // Either email or phone must be present
-        context.invalidate_if(
+        context = context.invalidate_if(
             self.email.is_none() && self.phone.is_none(),
             ContactDataInvalidity::Incomplete,
         );
@@ -110,13 +104,10 @@ impl Validate for Customer {
     type Invalidity = CustomerInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::new();
-        context.invalidate_if(self.name.is_empty(), CustomerInvalidity::NameEmpty);
-        context.validate_and_map(
-            &self.contact_data,
-            CustomerInvalidity::ContactData,
-        );
-        context.into()
+        ValidationContext::new()
+            .invalidate_if(self.name.is_empty(), CustomerInvalidity::NameEmpty)
+            .validate_and_map(&self.contact_data, CustomerInvalidity::ContactData)
+            .into()
     }
 }
 
@@ -138,12 +129,9 @@ impl Validate for Quantity {
     type Invalidity = QuantityInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::new();
-        context.invalidate_if(
-            *self < Self::min(),
-            QuantityInvalidity::MinValue,
-        );
-        context.into()
+        ValidationContext::new()
+            .invalidate_if(*self < Self::min(), QuantityInvalidity::MinValue)
+            .into()
     }
 }
 
@@ -163,10 +151,10 @@ impl Validate for Reservation {
     type Invalidity = ReservationInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::new();
-        context.validate_and_map(&self.customer, ReservationInvalidity::Customer);
-        context.validate_and_map(&self.quantity, ReservationInvalidity::Quantity);
-        context.into()
+        ValidationContext::new()
+            .validate_and_map(&self.customer, ReservationInvalidity::Customer)
+            .validate_and_map(&self.quantity, ReservationInvalidity::Quantity)
+            .into()
     }
 }
 

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -77,17 +77,11 @@ impl Validate for ContactData {
     type Invalidity = ContactDataInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::new();
-        // Validate all optional members if present
-        if let Some(ref email) = self.email {
-            context = context.validate_and_map(email, ContactDataInvalidity::Email)
-        }
-        if let Some(ref phone) = self.phone {
-            context = context.validate_and_map(phone, ContactDataInvalidity::Phone)
-        }
-        // Either email or phone must be present
-        context
+        ValidationContext::new()
+            .validate_and_map(&self.email, ContactDataInvalidity::Email)
+            .validate_and_map(&self.phone, ContactDataInvalidity::Phone)
             .invalidate_if(
+                // Either email or phone must be present
                 self.email.is_none() && self.phone.is_none(),
                 ContactDataInvalidity::Incomplete,
             )

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -20,7 +20,7 @@ impl Validate for Email {
     type Invalidity = EmailInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         context.invalidate_if(
             self.0.len() < Self::min_len(),
             EmailInvalidity::MinLength,
@@ -51,7 +51,7 @@ impl Validate for Phone {
     type Invalidity = PhoneInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         let len = self.0.chars().filter(|c| !c.is_whitespace()).count();
         context.invalidate_if(
             len < Self::min_len(),
@@ -78,7 +78,7 @@ impl Validate for ContactData {
     type Invalidity = ContactDataInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         if let Some(ref email) = self.email {
             context.validate_and_map(email, ContactDataInvalidity::Email)
         }
@@ -110,7 +110,7 @@ impl Validate for Customer {
     type Invalidity = CustomerInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         context.invalidate_if(self.name.is_empty(), CustomerInvalidity::NameEmpty);
         context.validate_and_map(
             &self.contact_data,
@@ -138,7 +138,7 @@ impl Validate for Quantity {
     type Invalidity = QuantityInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         context.invalidate_if(
             *self < Self::min(),
             QuantityInvalidity::MinValue,
@@ -163,7 +163,7 @@ impl Validate for Reservation {
     type Invalidity = ReservationInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
-        let mut context = ValidationContext::valid();
+        let mut context = ValidationContext::new();
         context.validate_and_map(&self.customer, ReservationInvalidity::Customer);
         context.validate_and_map(&self.quantity, ReservationInvalidity::Quantity);
         context.into()

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -1,11 +1,5 @@
 use semval::prelude::*;
 
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub struct UnexpectedValue<T> {
-    pub expected: T,
-    pub actual: T,
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct Email(String);
 
@@ -18,7 +12,7 @@ impl Email {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum EmailInvalidity {
-    MinLen(UnexpectedValue<usize>),
+    MinLength,
     Format,
 }
 
@@ -29,10 +23,7 @@ impl Validate for Email {
         let mut context = ValidationContext::valid();
         context.invalidate_if(
             self.0.len() < Self::min_len(),
-            EmailInvalidity::MinLen(UnexpectedValue {
-                expected: Self::min_len(),
-                actual: self.0.len(),
-            }),
+            EmailInvalidity::MinLength,
         );
         context.invalidate_if(
             self.0.chars().filter(|c| *c == '@').count() != 1,
@@ -53,7 +44,7 @@ impl Phone {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum PhoneInvalidity {
-    MinLen(UnexpectedValue<usize>),
+    MinLength,
 }
 
 impl Validate for Phone {
@@ -64,10 +55,7 @@ impl Validate for Phone {
         let len = self.0.chars().filter(|c| !c.is_whitespace()).count();
         context.invalidate_if(
             len < Self::min_len(),
-            PhoneInvalidity::MinLen(UnexpectedValue {
-                expected: Self::min_len(),
-                actual: len,
-            }),
+            PhoneInvalidity::MinLength,
         );
         context.into()
     }
@@ -143,7 +131,7 @@ impl Quantity {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum QuantityInvalidity {
-    Min(UnexpectedValue<Quantity>),
+    MinValue,
 }
 
 impl Validate for Quantity {
@@ -153,10 +141,7 @@ impl Validate for Quantity {
         let mut context = ValidationContext::valid();
         context.invalidate_if(
             *self < Self::min(),
-            QuantityInvalidity::Min(UnexpectedValue {
-                expected: Self::min(),
-                actual: *self,
-            }),
+            QuantityInvalidity::MinValue,
         );
         context.into()
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-use core::fmt::{self, Display, Formatter};
-
-use std::error::Error as StdError;
-
 use smallvec::SmallVec;
 
 const SMALLVEC_ARRAY_LEN: usize = 8;
@@ -142,26 +138,6 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.invalidities.into_iter()
-    }
-}
-
-#[cfg(feature = "std")]
-impl<V> StdError for Context<V> where V: Invalidity + Display {}
-
-impl<V> Display for Context<V>
-where
-    V: Invalidity + Display,
-{
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str("[")?;
-        for (i, v) in self.invalidities.iter().enumerate() {
-            if i > 0 {
-                f.write_str(" ")?;
-            }
-            write!(f, "{}", v)?;
-        }
-        f.write_str("]")?;
-        Ok(())
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,72 +10,72 @@ const SMALLVEC_ARRAY_LEN: usize = 8;
 
 type SmallVecArray<V> = [V; SMALLVEC_ARRAY_LEN];
 
-/// A collection of violations resulting from a validation
+/// A collection of invalidities resulting from a validation
 ///
-/// Collects violations that are detected while performing
+/// Collects invalidities that are detected while performing
 /// a validation.
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Context<V>
 where
-    V: Validation,
+    V: Invalidity,
 {
-    violations: SmallVec<SmallVecArray<V>>,
+    invalidities: SmallVec<SmallVecArray<V>>,
 }
 
 impl<V> Context<V>
 where
-    V: Validation,
+    V: Invalidity,
 {
-    /// Create a new valid context without any violations.
+    /// Create a new valid context
     #[inline]
     pub fn valid() -> Self {
         Self {
-            violations: SmallVec::new(),
+            invalidities: SmallVec::new(),
         }
     }
 
-    /// Check if the context doesn't have any violations
+    /// Check if the context is still valid
     #[inline]
     pub fn is_valid(&self) -> bool {
-        !self.violations.is_empty()
+        !self.invalidities.is_empty()
     }
 
-    /// The violations collected so far
+    /// All validation failures collected so far
     #[inline]
-    pub fn violations(&self) -> impl Iterator<Item = &V> {
-        self.violations.iter()
+    pub fn invalidities(&self) -> impl Iterator<Item = &V> {
+        self.invalidities.iter()
     }
 
-    /// Count the number of violations collected so far
+    /// Count the number of invalidities collected so far
+    ///
+    /// A shortcut for `invalidities().count()` that might be more efficient.
     #[inline]
-    pub fn count_violations(&self) -> usize {
-        self.violations.len()
+    pub fn count_invalidities(&self) -> usize {
+        self.invalidities.len()
     }
 
-    /// Add a new violation to the context
+    /// Record a new invalidity within this context
     #[inline]
-    pub fn add_violation(&mut self, violation: impl Into<V>) {
-        self.violations.push(violation.into());
+    pub fn invalidate(&mut self, invalidity: impl Into<V>) {
+        self.invalidities.push(invalidity.into());
     }
 
-    /// Conditionally add a new violation to the context
+    /// Conditionally record a new invalidity within this context
     #[inline]
-    pub fn add_violation_if(&mut self, is_violated: bool, violation: impl Into<V>) {
+    pub fn invalidate_if(&mut self, is_violated: bool, invalidity: impl Into<V>) {
         if is_violated {
-            self.add_violation(violation);
+            self.invalidate(invalidity);
         }
     }
 
-    /// Merge with another context
     fn merge(&mut self, other: Self) {
-        self.violations.reserve(other.violations.len());
-        for error in other.violations.into_iter() {
-            self.violations.push(error);
+        self.invalidities.reserve(other.invalidities.len());
+        for error in other.invalidities.into_iter() {
+            self.invalidities.push(error);
         }
     }
 
-    /// Merge a validation result into the context
     #[inline]
     fn merge_result(&mut self, res: Result<V>) {
         if let Err(other) = res {
@@ -83,42 +83,38 @@ where
         }
     }
 
-    /// Merge an unrelated validation into the context
     fn map_and_merge_result<F, U>(&mut self, res: Result<U>, map: F)
     where
         F: Fn(U) -> V,
-        U: Validation,
+        U: Invalidity,
     {
         if let Err(other) = res {
-            self.violations.reserve(other.violations.len());
-            for v in other.violations.into_iter() {
-                self.violations.push(map(v))
+            self.invalidities.reserve(other.invalidities.len());
+            for v in other.invalidities.into_iter() {
+                self.invalidities.push(map(v))
             }
         }
     }
 
     /// Validate the target and merge the result into this context
     #[inline]
-    pub fn validate(&mut self, target: &impl Validate<Validation = V>) {
+    pub fn validate(&mut self, target: &impl Validate<Invalidity = V>) {
         self.merge_result(target.validate());
     }
 
-    /// Validate the target and merge the result after mapping into this context
+    /// Validate the target, map the result, and merge it into this context
     #[inline]
-    pub fn validate_and_map<F, U>(&mut self, target: &impl Validate<Validation = U>, map: F) where
+    pub fn validate_and_map<F, U>(&mut self, target: &impl Validate<Invalidity = U>, map: F) where
         F: Fn(U) -> V,
-        U: Validation,
+        U: Invalidity,
     {
         self.map_and_merge_result(target.validate(), map);
     }
 
     /// Finish the current validation of this context with a result
-    ///
-    /// Returns the context wrapped into `Err` if it has collected
-    /// one or more violations or `Ok` if the context is valid.
     #[inline]
     pub fn into_result(self) -> Result<V> {
-        if self.violations.is_empty() {
+        if self.invalidities.is_empty() {
             Ok(())
         } else {
             Err(self)
@@ -128,7 +124,7 @@ where
 
 impl<V> Default for Context<V>
 where
-    V: Validation,
+    V: Invalidity,
 {
     fn default() -> Self {
         Self::valid()
@@ -137,7 +133,7 @@ where
 
 impl<V> Into<Result<V>> for Context<V>
 where
-    V: Validation,
+    V: Invalidity,
 {
     fn into(self) -> Result<V> {
         self.into_result()
@@ -145,29 +141,29 @@ where
 }
 
 /// Consume the validation context and transform it into
-/// a sequence of the collected violations.
+/// a sequence of the collected invalidities.
 impl<V> IntoIterator for Context<V>
 where
-    V: Validation,
+    V: Invalidity,
 {
     type Item = V;
     type IntoIter = smallvec::IntoIter<SmallVecArray<V>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.violations.into_iter()
+        self.invalidities.into_iter()
     }
 }
 
 #[cfg(feature = "std")]
-impl<V> StdError for Context<V> where V: Validation + Display {}
+impl<V> StdError for Context<V> where V: Invalidity + Display {}
 
 impl<V> Display for Context<V>
 where
-    V: Validation + Display,
+    V: Invalidity + Display,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str("[")?;
-        for (i, v) in self.violations().enumerate() {
+        for (i, v) in self.invalidities().enumerate() {
             if i > 0 {
                 f.write_str(" ")?;
             }
@@ -186,7 +182,7 @@ mod tests {
     fn valid_context() {
         let context = Context::<()>::valid();
         assert!(!context.is_valid());
-        assert_eq!(0, context.count_violations());
+        assert_eq!(0, context.count_invalidities());
         assert!(context.into_result().is_ok());
     }
 
@@ -196,18 +192,18 @@ mod tests {
     }
 
     #[test]
-    fn add_error() {
+    fn invalidate() {
         let mut context = Context::<()>::valid();
         assert!(!context.is_valid());
         for _ in 0..=SMALLVEC_ARRAY_LEN {
-            let violations_before = context.count_violations();
-            context.add_violation(());
+            let invalidities_before = context.count_invalidities();
+            context.invalidate(());
             assert!(context.is_valid());
-            let violations_after = context.count_violations();
-            assert_eq!(violations_after, violations_before + 1);
+            let invalidities_after = context.count_invalidities();
+            assert_eq!(invalidities_after, invalidities_before + 1);
         }
-        assert_eq!(SMALLVEC_ARRAY_LEN + 1, context.count_violations());
-        assert_eq!(context.count_violations(), context.violations().count());
+        assert_eq!(SMALLVEC_ARRAY_LEN + 1, context.count_invalidities());
+        assert_eq!(context.count_invalidities(), context.invalidities().count());
         assert!(context.into_result().is_err());
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,16 +63,16 @@ where
         }
     }
 
-    // TODO: Make public?
+    /// Merge the results of another validation
     #[inline]
-    fn merge_result(&mut self, res: Result<V>) {
+    pub fn merge_result(&mut self, res: Result<V>) {
         if let Err(other) = res {
             self.merge(other);
         }
     }
 
-    // TODO: Make public?
-    fn map_and_merge_result<F, U>(&mut self, res: Result<U>, map: F)
+    /// Merge the mapped results of another validation
+    pub fn map_and_merge_result<F, U>(&mut self, res: Result<U>, map: F)
     where
         F: Fn(U) -> V,
         U: Invalidity,

--- a/src/context.rs
+++ b/src/context.rs
@@ -64,6 +64,8 @@ where
     }
 
     /// Merge the results of another validation
+    ///
+    /// Needed for collecting results from custom validation functions.
     #[inline]
     pub fn merge_result(self, res: Result<V>) -> Self {
         if let Err(other) = res {
@@ -74,6 +76,8 @@ where
     }
 
     /// Merge the mapped results of another validation
+    ///
+    /// Needed for collecting results from custom validation functions.
     pub fn map_and_merge_result<F, U>(mut self, res: Result<U>, map: F) -> Self
     where
         F: Fn(U) -> V,

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,7 +29,7 @@ where
 {
     /// Create a new valid and empty context
     #[inline]
-    pub fn valid() -> Self {
+    pub fn new() -> Self {
         Self {
             invalidities: SmallVec::new(),
         }
@@ -116,7 +116,7 @@ where
     V: Invalidity,
 {
     fn default() -> Self {
-        Self::valid()
+        Self::new()
     }
 }
 
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn valid_context() {
-        let context = Context::<()>::valid();
+        let context = Context::<()>::new();
         assert!(!context.is_valid());
         assert!(context.invalidities.is_empty());
         assert!(context.into_result().is_ok());
@@ -179,12 +179,12 @@ mod tests {
 
     #[test]
     fn default_context() {
-        assert_eq!(Context::<()>::valid(), Context::<()>::default());
+        assert_eq!(Context::<()>::new(), Context::<()>::default());
     }
 
     #[test]
     fn invalidate() {
-        let mut context = Context::<()>::valid();
+        let mut context = Context::<()>::new();
         assert!(!context.is_valid());
         for _ in 0..=SMALLVEC_ARRAY_LEN {
             let invalidities_before = context.invalidities.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,13 @@ pub type Result<V> = core::result::Result<(), Context<V>>;
 /// (`enum`) with one variant per objective. Some of the variants may
 /// recursively wrap an invalidity of a subordinate validation to trace
 /// back root causes.
+///
+/// Implementations are required to implement `Debug` to enable analysis
+/// and low-level logging of those recursively wrapped sum types.
+///
+/// The trait bound `Any` is implicitly implemented for most types and
+/// enables basic type inspection and downcasting for generically handling
+/// validation results though runtime reflection.
 pub trait Invalidity: Any + Debug {}
 
 impl<V> Invalidity for V where V: Any + Debug {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod context;
 /// A proposed set of imports to ease usage of this crate.
 pub mod prelude {
     pub use super::{
-        context::Context as ValidationContext, Result as ValidationResult, Validate, Invalidity,
+        context::Context as ValidationContext, Invalidity, Result as ValidationResult, Validate,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,11 @@ pub trait Validate {
     fn validate(&self) -> Result<Self::Invalidity>;
 }
 
-/// Apply `Validate` to an option that implicitly evaluates to `Ok`
+/// Validate `Some` or otherwise implicitly evaluate to `Ok`
 /// in case of `None`
+///
+/// If the absence of an optional value is considered a validation
+/// error this must be checked separately.
 impl<V> Validate for Option<V>
 where
     V: Validate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
         type Invalidity = ();
 
         fn validate(&self) -> Result<Self::Invalidity> {
-            Context::valid().into()
+            Context::new().into()
         }
     }
 


### PR DESCRIPTION
This PR introduces a major renaming to

- improve consistency
- reduce the number of distinct verbs and terms

~~The term *invalidity* is slightly inconvenient in its plural form, but this is only a minor drawback in contrast to the benefits. Any proposals to avoid it in the public API of `ValidationContext`?~~ Done, i.e.stripped down the public interface of `ValidationContext`.

I would like to shrink the public API of to the absolute minimum! Is the `IntoIterator` trait sufficient to finally retrieve all collected invalidities `ValidationContext` only once?

I also removed unnecessary complexity from the example code to make it more comprehensible.