### PR TITLE
Add ValidateFrom/Into traits for type-save validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added traits `ValidatedFrom` and `IntoValidated` for type-save validation
+
 ### Changed
 
 - Generalize `validate()` for all `Invalidity` types that implement `Into`


### PR DESCRIPTION
Motivated by suggestions on [Reddit](https://www.reddit.com/r/rust/comments/cz4nlf/semantic_validation_in_rust/eywi41o?utm_source=share&utm_medium=web2x) I have added 2 traits that pave the way to type-safe validation. I expect that those traits are mainly used on the aggregate level according to DDD.

The example demonstrates how to wrap entities into a *newtype* to distinguish _unvalidated_ input data from _validated_ domain entities. The unvalidated input type could be any type.

After ingesting and validating input data, consumers are free to decide if they
- reject results with validation errors,
- are able to handle or fix the validation errors, or
- accept the result despite validation errors.

The _post-validation_ approach (validate **after** conversion) introduced here should be sufficient for most use cases. It simplifies the result type, i.e. the payload/entity type is the same for both success and failure outcomes.

**update**:
The following Trait/Fn names were discussed:

- ~`validate_into()`~ (this does not suit because the validation is done **after** the `into` conversion)
- `into_validated()` (favorite)
- ~`into_validate()`~ (this does not fit well because we convert `into` a validate**d** result)
- ~`validate_from()`~ (this does not fit well because the result is validate**d**)
- `validated_from()` (favorite)
- `from_validated()` (variant)