### PR TITLE
Generalize validate() for convertible Invalidity types

### DIFF
--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -107,13 +107,21 @@ enum CustomerInvalidity {
     ContactData(ContactDataInvalidity),
 }
 
+// This conversion allows to use ValidationContext::validate()
+// instead of ValidationContext::validate_and_map().
+impl From<ContactDataInvalidity> for CustomerInvalidity {
+    fn from(from: ContactDataInvalidity) -> Self {
+        CustomerInvalidity::ContactData(from)
+    }
+}
+
 impl Validate for Customer {
     type Invalidity = CustomerInvalidity;
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
             .invalidate_if(self.name.is_empty(), CustomerInvalidity::NameEmpty)
-            .validate_and_map(&self.contact_data, CustomerInvalidity::ContactData)
+            .validate(&self.contact_data)
             .into()
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -94,8 +94,11 @@ where
 
     /// Validate the target and merge the result into this context
     #[inline]
-    pub fn validate(self, target: &impl Validate<Invalidity = V>) -> Self {
-        self.merge_result(target.validate())
+    pub fn validate<U>(self, target: &impl Validate<Invalidity = U>) -> Self
+    where
+        U: Invalidity + Into<V>,
+    {
+        self.map_and_merge_result(target.validate(), |u| u.into())
     }
 
     /// Validate the target, map the result, and merge it into this context

--- a/src/context.rs
+++ b/src/context.rs
@@ -98,7 +98,7 @@ where
     where
         U: Invalidity + Into<V>,
     {
-        self.map_and_merge_result(target.validate(), |u| u.into())
+        self.validate_and_map(target, Into::into)
     }
 
     /// Validate the target, map the result, and merge it into this context


### PR DESCRIPTION
As suggested on [Reddit](https://www.reddit.com/r/rust/comments/cz4nlf/semantic_validation_in_rust/eyycy7y?utm_source=share&utm_medium=web2x), a simple generalization and nice usability improvement.

I only changed the implementation of a single `Invalidity` type in the example code to demonstrate both variants. Using `validate_and_map()` might be more concise if the conversion is needed only once. And it is still needed if no such canonical conversion exists.