### PR TITLE
Rename map_and_/_and_map functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed functions with a *map* parameter:
+    - `validate_and_map()` becomes `validate_with()`
+    -  `map_and_merge_result()` becomes `merge_result_with()`
+
 ### Removed
 
 ## [0.1.1] - 2019-09-09

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ impl Validate for ContactData {
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
-            .validate_and_map(&self.email, ContactDataInvalidity::EmailAddress)
-            .validate_and_map(&self.phone, ContactDataInvalidity::PhoneNumber)
+            .validate_with(&self.email, ContactDataInvalidity::EmailAddress)
+            .validate_with(&self.phone, ContactDataInvalidity::PhoneNumber)
             .invalidate_if(
                 // Either email or phone must be present
                 self.email.is_none() && self.phone.is_none(),

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -84,8 +84,8 @@ impl Validate for ContactData {
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
-            .validate_and_map(&self.email, ContactDataInvalidity::Email)
-            .validate_and_map(&self.phone, ContactDataInvalidity::Phone)
+            .validate_from(&self.email, ContactDataInvalidity::Email)
+            .validate_from(&self.phone, ContactDataInvalidity::Phone)
             .invalidate_if(
                 // Either email or phone must be present
                 self.email.is_none() && self.phone.is_none(),
@@ -108,7 +108,7 @@ enum CustomerInvalidity {
 }
 
 // This conversion allows to use ValidationContext::validate()
-// instead of ValidationContext::validate_and_map().
+// instead of ValidationContext::validate_from().
 impl From<ContactDataInvalidity> for CustomerInvalidity {
     fn from(from: ContactDataInvalidity) -> Self {
         CustomerInvalidity::ContactData(from)
@@ -171,8 +171,8 @@ impl Validate for Reservation {
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
-            .validate_and_map(&self.customer, ReservationInvalidity::Customer)
-            .validate_and_map(&self.quantity, ReservationInvalidity::Quantity)
+            .validate_from(&self.customer, ReservationInvalidity::Customer)
+            .validate_from(&self.quantity, ReservationInvalidity::Quantity)
             .into()
     }
 }

--- a/examples/reservation.rs
+++ b/examples/reservation.rs
@@ -84,8 +84,8 @@ impl Validate for ContactData {
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
-            .validate_from(&self.email, ContactDataInvalidity::Email)
-            .validate_from(&self.phone, ContactDataInvalidity::Phone)
+            .validate_with(&self.email, ContactDataInvalidity::Email)
+            .validate_with(&self.phone, ContactDataInvalidity::Phone)
             .invalidate_if(
                 // Either email or phone must be present
                 self.email.is_none() && self.phone.is_none(),
@@ -108,7 +108,7 @@ enum CustomerInvalidity {
 }
 
 // This conversion allows to use ValidationContext::validate()
-// instead of ValidationContext::validate_from().
+// instead of ValidationContext::validate_with().
 impl From<ContactDataInvalidity> for CustomerInvalidity {
     fn from(from: ContactDataInvalidity) -> Self {
         CustomerInvalidity::ContactData(from)
@@ -171,8 +171,8 @@ impl Validate for Reservation {
 
     fn validate(&self) -> ValidationResult<Self::Invalidity> {
         ValidationContext::new()
-            .validate_from(&self.customer, ReservationInvalidity::Customer)
-            .validate_from(&self.quantity, ReservationInvalidity::Quantity)
+            .validate_with(&self.customer, ReservationInvalidity::Customer)
+            .validate_with(&self.quantity, ReservationInvalidity::Quantity)
             .into()
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -108,7 +108,7 @@ where
     /// Merge the mapped results of another validation
     ///
     /// Needed for collecting results from custom validation functions.
-    pub fn merge_result_from<F, U>(self, res: Result<U>, map: F) -> Self
+    pub fn merge_result_with<F, U>(self, res: Result<U>, map: F) -> Self
     where
         F: Fn(U) -> V,
         U: Invalidity,
@@ -123,7 +123,7 @@ where
     /// Merge the mapped results of another validation
     #[deprecated(
         since = "0.2.0",
-        note = "Please use [`merge_result_from`](#method.merge_result_from) instead"
+        note = "Please use [`merge_result_with`](#method.merge_result_with) instead"
     )]
     pub fn map_and_merge_result<F, U>(self, res: Result<U>, map: F) -> Self
     where
@@ -143,30 +143,30 @@ where
     where
         U: Invalidity + Into<V>,
     {
-        self.validate_from(target, Into::into)
+        self.validate_with(target, Into::into)
     }
 
     /// Validate the target and merge the mapped result into this context
     #[inline]
-    pub fn validate_from<F, U>(self, target: &impl Validate<Invalidity = U>, map: F) -> Self
+    pub fn validate_with<F, U>(self, target: &impl Validate<Invalidity = U>, map: F) -> Self
     where
         F: Fn(U) -> V,
         U: Invalidity,
     {
-        self.merge_result_from(target.validate(), map)
+        self.merge_result_with(target.validate(), map)
     }
 
     /// Validate the target, map the result, and merge it into this context
     #[deprecated(
         since = "0.2.0",
-        note = "Please use [`validate_from`](#method.validate_from) instead"
+        note = "Please use [`validate_with`](#method.validate_with) instead"
     )]
     pub fn validate_and_map<F, U>(self, target: &impl Validate<Invalidity = U>, map: F) -> Self
     where
         F: Fn(U) -> V,
         U: Invalidity,
     {
-        self.validate_from(target, map)
+        self.validate_with(target, map)
     }
 
     /// Finish the current validation of this context with a result

--- a/src/context.rs
+++ b/src/context.rs
@@ -108,6 +108,23 @@ where
     /// Merge the mapped results of another validation
     ///
     /// Needed for collecting results from custom validation functions.
+    pub fn merge_result_from<F, U>(self, res: Result<U>, map: F) -> Self
+    where
+        F: Fn(U) -> V,
+        U: Invalidity,
+    {
+        if let Err(other) = res {
+            self.merge_exact_size_iter(other.invalidities.into_iter().map(map))
+        } else {
+            self
+        }
+    }
+
+    /// Merge the mapped results of another validation
+    #[deprecated(
+        since = "0.2.0",
+        note = "Please use [`merge_result_from`](#method.merge_result_from) instead"
+    )]
     pub fn map_and_merge_result<F, U>(self, res: Result<U>, map: F) -> Self
     where
         F: Fn(U) -> V,
@@ -126,17 +143,30 @@ where
     where
         U: Invalidity + Into<V>,
     {
-        self.validate_and_map(target, Into::into)
+        self.validate_from(target, Into::into)
+    }
+
+    /// Validate the target and merge the mapped result into this context
+    #[inline]
+    pub fn validate_from<F, U>(self, target: &impl Validate<Invalidity = U>, map: F) -> Self
+    where
+        F: Fn(U) -> V,
+        U: Invalidity,
+    {
+        self.merge_result_from(target.validate(), map)
     }
 
     /// Validate the target, map the result, and merge it into this context
-    #[inline]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Please use [`validate_from`](#method.validate_from) instead"
+    )]
     pub fn validate_and_map<F, U>(self, target: &impl Validate<Invalidity = U>, map: F) -> Self
     where
         F: Fn(U) -> V,
         U: Invalidity,
     {
-        self.map_and_merge_result(target.validate(), map)
+        self.validate_from(target, map)
     }
 
     /// Finish the current validation of this context with a result


### PR DESCRIPTION
This is a proposal to get rid of some clumsy and inconsistently named functions in ValidationContext:

- `validate()` as before
- `validate_with()` replaces `validate_and_map()`
- `merge_result()` as before
- `merge_result_with()` replaces `map_and_merge_result()`

After renaming the function names with the additional `map: Fn` closure can easily be identified by their common suffix `_with`.

### Roadmap

#### v0.1.2
- Introduce new function names
- Mark existing functions as *deprecated* in v0.2.0

#### v0.2.0
- Remove deprecated functions