### PR TITLE
Add as_ref() to Validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2022-11-24
+
+- Add `as_ref()` to `Validated`
+
+### BREAKING CHANGES
+
+- As `Validated` now has an inherent `as_ref()` method, code that
+  used to call `AsRef::as_ref` on it may now behave differently.
+  `AsRef` impl is still available and can be called explicitly,
+  or simply use `Deref` instead.
+
 ## [0.4.1] - 2022-10-21
 
 - Add support for `std::borrow::Cow`
@@ -54,7 +65,7 @@ No (notable) API changes.
 
 ## 0.1.4 - 2020-05-23
 
-***Unreleased***
+**_Unreleased_**
 
 ## 0.1.3 - 2019-11-28
 
@@ -66,7 +77,7 @@ No (notable) API changes.
 
 ### Changed
 
-- Renamed functions with a *map* parameter:
+- Renamed functions with a _map_ parameter:
   - `validate_and_map()` becomes `validate_with()`
   - `map_and_merge_result()` becomes `merge_result_with()`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 name = "semval"
 description = "Semantic validation"
 keywords = ["semantic", "validation"]
-version = "0.4.1"
+version = "0.5.0"
 license = "MPL-2.0"
 readme = "README.md"
 authors = ["slowtec GmbH <post@slowtec.de>", "Uwe Klotz <uwe.klotz@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,12 +182,17 @@ impl<T> Validated<T> {
     pub fn into(self) -> T {
         self.0
     }
+
+    /// Converts from `&Validated<T>` to `Validated<&T>`.
+    #[inline]
+    pub const fn as_ref(&self) -> Validated<&T> {
+        Validated(&self.0)
+    }
 }
 
 impl<T> AsRef<T> for Validated<T> {
     fn as_ref(&self) -> &T {
-        let Self(inner) = self;
-        inner
+        self
     }
 }
 
@@ -195,7 +200,7 @@ impl<T> Deref for Validated<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.as_ref()
+        &self.0
     }
 }
 


### PR DESCRIPTION
Adds `as_ref` to `Validated`.

Note: this is a source-breaking change (anyone using the `AsRef<T>` impl will need to either call that directly, or use the deref) - and as such should probably be bumped to 0.5.0.

Resolves #9 